### PR TITLE
부모의 보모 매핑리스트 응답 결과 수정

### DIFF
--- a/backend/src/controllers/parent.controller.ts
+++ b/backend/src/controllers/parent.controller.ts
@@ -5,6 +5,7 @@ import { RequestToParent } from "../entity/RequestToParent";
 import { Mapping } from "../entity/Mapping";
 import { WorkDiary } from "../entity/WorkDiary";
 import { WorkDiaryImg } from "../entity/WorkDiaryImg";
+import { BabySitter } from "../entity/BabySitter";
 
 const getParentInfo = async (req: Request, res: Response, next: NextFunction) => {
     const parent_id: number = +req.params.parentId;
@@ -95,13 +96,17 @@ const getMainPage = async (req: Request, res: Response, next: NextFunction) => {
         if (existMappingList.length !== 0) {
             // status 값에 따라 매핑 정보인지 요청 정보인지 나눔
             existMappingList.map((m) => {
+                
                 if (m.status === 1) {
                     mapping_info.push(m);
                 }
-                else if (m.status === 2) {
+                else {
                     request_info.push(m);
                 }
+                
             })
+
+            
             
             // 매핑 정보가 있는 경우
             if (mapping_info.length !== 0) {

--- a/backend/src/entity/Mapping.ts
+++ b/backend/src/entity/Mapping.ts
@@ -53,6 +53,8 @@ export class Mapping extends BaseEntity {
     static async findMappingList(parentId: number) {
         return await this.createQueryBuilder("mapping")
             .leftJoinAndSelect("mapping.babySitter", "babySitter")
+            .leftJoinAndSelect("babySitter.user", "user")
+            .select(["mapping.mappingId", "mapping.status", "babySitter.bsId", "babySitter.age", "babySitter.region", "babySitter.career", "user.username"])
             .where("mapping.parentId = :parentId", { parentId: parentId })
             .getMany();
     }


### PR DESCRIPTION
- 부모 메인페이지에서 보모의 매핑 정보만 반환하는 부분에서 보모 개인정보를 포함하여 응답하도록 기능 개선

`http://{{IP}}:3000/parent/main/{{parentId}}` GET 요청 응답 예시
```
{
    "message": "매핑 리스트",
    "mapping_info": [
        {
            "mappingId": 1,
            "status": 1,
            "babySitter": {
                "bsId": 1,
                "age": 60,
                "region": "대구광역시",
                "career": "경력 8년차",
                "user": {
                    "username": "김미자"
                }
            }
        }
    ]
}
```