### PR TITLE
퇴근일지 응답 관련 코드 최적화

### DIFF
--- a/backend/src/controllers/parent.controller.ts
+++ b/backend/src/controllers/parent.controller.ts
@@ -1,11 +1,9 @@
 import { Request, Response, NextFunction } from "express";
 import { User } from '../entity/User';
 import { Parent } from '../entity/Parent';
-import { RequestToParent } from "../entity/RequestToParent";
 import { Mapping } from "../entity/Mapping";
 import { WorkDiary } from "../entity/WorkDiary";
 import { WorkDiaryImg } from "../entity/WorkDiaryImg";
-import { BabySitter } from "../entity/BabySitter";
 
 const getParentInfo = async (req: Request, res: Response, next: NextFunction) => {
     const parent_id: number = +req.params.parentId;
@@ -170,7 +168,7 @@ const rejectMapping = async (req: Request, res: Response, next: NextFunction) =>
     const mapping_info = await Mapping.findOne({mappingId: mappingId});
 
     if (mapping_info) {
-        await Mapping.delete({mappingId: mappingId})
+        await Mapping.delete({mappingId: mappingId, status: 2})
         .then(() => {
             res.status(200).json({
                 message: "보모의 매핑 요청 거절 완료"
@@ -188,53 +186,55 @@ const rejectMapping = async (req: Request, res: Response, next: NextFunction) =>
 }
 
 const getDailyDiary = async (req: Request, res: Response, next: NextFunction) => {
-    try {    
-        const mappingId: number = +req.params.mappingId;
+    const mappingId: number = +req.params.mappingId;
 
-        // mappingId를 이용하여 금일 퇴근일지 가져오기
-        const daily_work_diary = await WorkDiary.findDiarybyMappingId(mappingId);
-
-        // 가져온 퇴근일지 ID를 이용하여 금일 퇴근일지에 저장된 이미지 리스트 가져오기
-        const daily_diary_img_list = await WorkDiaryImg.findImgbyDiaryId(daily_work_diary.diaryId);
-
-        return res.status(200).json({
-            dailyDiary: daily_work_diary,
-            dailyImageList: daily_diary_img_list
-        })
-
-    }
-    // 올바르지 않은 mappingId 입력된 경우
-    catch(error) {
-        return res.status(400).json({
-            error,
-            message: "잘못된 매핑 ID가 입력됨"
+    // mappingId를 이용하여 금일 퇴근일지 가져오기
+    const daily_work_diary = await WorkDiary.findDiarybyMappingId(mappingId);
+    
+    if (daily_work_diary === undefined) {
+        return res.status(404).json({
+            message: "금일 작성된 퇴근일지가 존재하지 않습니다."
         });
+    }
+    else {
+        // 가져온 퇴근일지 ID를 이용하여 금일 퇴근일지에 저장된 이미지 리스트 가져오기
+        await WorkDiaryImg.findImgbyDiaryId(daily_work_diary.diaryId)
+        .then((result) => {
+            return res.status(200).json({
+                dailyDiary: daily_work_diary,
+                dailyImageList: result
+            })
+        })
+        .catch((err) => {
+            return res.status(400).json(err);
+        })
     }
 }
 
 const getCalendarDiary = async (req: Request, res: Response, next: NextFunction) => {
-    try {    
-        const mappingId: number = +req.params.mappingId;
-        const date: string = req.body.date; // ex) 2022-04-14
+    const mappingId: number = +req.params.mappingId;
+    const date: string = req.body.date; // ex) 2022-04-14
 
-        // mappingId, 날짜를 이용하여 특정 날짜의 퇴근일지 가져오기
-        const calendar_work_diary = await WorkDiary.findCalendarDiary(mappingId, date);
+    // mappingId, 날짜를 이용하여 특정 날짜의 퇴근일지 가져오기
+    const calendar_work_diary = await WorkDiary.findCalendarDiary(mappingId, date);
 
-        // 가져온 퇴근일지 ID, 날짜를 이용하여 특정 날짜에 작성된 퇴근일지 이미지 리스트 가져오기
-        const calendar_diary_img_list = await WorkDiaryImg.findImgUsingIdAndDate(calendar_work_diary.diaryId, date);
-
-        return res.status(200).json({
-            CalendarDiary: calendar_work_diary,
-            CalendarImageList: calendar_diary_img_list
+    if (calendar_work_diary === undefined) {
+        return res.status(404).json({
+            message: "해당 날짜에 작성된 퇴근일지가 존재하지 않습니다."
         })
-
     }
-    // 올바르지 않은 mappingId 또는 date가 입력된 경우
-    catch(error) {
-        return res.status(400).json({
-            error,
-            message: "잘못된 매핑 ID가 입력되었거나 해당 날짜에 대한 퇴근일지가 존재하지 않음"
-        });
+    else {
+        // 가져온 퇴근일지 ID, 날짜를 이용하여 특정 날짜에 작성된 퇴근일지 이미지 리스트 가져오기
+        await WorkDiaryImg.findImgUsingIdAndDate(calendar_work_diary.diaryId, date)
+        .then((result) => {
+            return res.status(200).json({
+                CalendarDiary: calendar_work_diary,
+                CalendarImageList: result
+            })
+        })
+        .catch((err) => {
+            res.status(400).json(err);
+        })
     }
 }
 

--- a/backend/src/entity/WorkDiary.ts
+++ b/backend/src/entity/WorkDiary.ts
@@ -41,7 +41,7 @@ export class WorkDiary extends BaseEntity {
         return await this.createQueryBuilder("work_diary")
             .where("work_diary.mappingId = :mappingId", {mappingId: mappingId})
             .andWhere("DATE_FORMAT(work_diary.createdAt, '%Y-%m-%d') = :date", {date: year + "-" + month + "-" + day})
-            .getOneOrFail();
+            .getOne();
     }
 
     // 캘린더에서 클릭한 날짜에 작성된  퇴근일지 가져오기
@@ -50,6 +50,6 @@ export class WorkDiary extends BaseEntity {
         return await this.createQueryBuilder("work_diary")
             .where("work_diary.mappingId = :mappingId", {mappingId: mappingId})
             .andWhere("DATE_FORMAT(work_diary.createdAt, '%Y-%m-%d') = :date", {date: date})
-            .getOneOrFail();
+            .getOne();
     }
 }


### PR DESCRIPTION
1. 금일 퇴근일지, 캘린더 퇴근일지 코드 최적화 및 요청에 대한 응답 결과 수정

**금일 작성된 퇴근일지 존재하지 않는 경우**
```json
{
    "message": "금일 작성된 퇴근일지가 존재하지 않습니다."
}
```

**특정 날짜에 작성된 퇴근일지가 존재하지 않는 경우**
```json
{
    "message": "해당 날짜에 작성된 퇴근일지가 존재하지 않습니다."
}
```

3. `await Mapping.delete({mappingId: mappingId, status: 2})` 보모의 매핑 요청 거절할 때 조건으로 status: 2 추가. ⇒ 조건 없는 경우 status=1 인 인스턴스 지워지는 경우 방지